### PR TITLE
docs: add english version of PowerShell script docs

### DIFF
--- a/ActiveDirectory/user/inform_user_passwordexpired.md
+++ b/ActiveDirectory/user/inform_user_passwordexpired.md
@@ -1,0 +1,33 @@
+# inform_user_passwordexpired.ps1
+
+This script notifies Active Directory users by email when their passwords will expire soon.
+
+## How It Works
+1. Starts a transcript and logs the start and end of the run.
+2. Verifies that PowerShell 7 or later and the **ActiveDirectory** module are available.
+3. Finds all users whose passwords were set more than `passwordExpireInDays` days ago and do not have "Password never expires" enabled.
+4. Sends an email for each user through the provided SMTP server.
+5. Outputs information about each send attempt and logs any errors.
+
+## Parameters
+- **csvpath** *(optional)*: Path for optional CSV export. Default: `c:\temp\output.csv`.
+- **encoding** *(optional)*: CSV encoding (`UTF8`, `ASCII`, `UTF7`, `UTF32`, `Default`, `Unicode`).
+- **delimiter** *(optional)*: CSV delimiter (`;`, `,`, ``t`, `|`).
+- **smtpServer** *(required)*: Address of the SMTP server.
+- **smtpPort** *(required)*: Port of the SMTP server. Default: `25`.
+- **passwordExpireInDays** *(required)*: Days before expiry to start notifying users.
+- **emailSubject** *(required)*: Subject line of the notification.
+- **smtpmailuser** *(required)*: Sender address.
+
+## Dependencies
+- PowerShell 7 or later
+- Module **shibis-pwsh-admin-module**
+- ActiveDirectory module
+
+## Example
+```powershell
+./inform_user_passwordexpired.ps1 -smtpServer "smtp.domain.tld" -smtpPort 587 -passwordExpireInDays 5 -emailSubject "Password expiring" -smtpmailuser "admin@domain.tld"
+```
+
+## Notes
+- Version: 1.0

--- a/ActiveDirectory/user/userInformations.md
+++ b/ActiveDirectory/user/userInformations.md
@@ -1,0 +1,29 @@
+# userInformations.ps1
+
+This script retrieves detailed information about Active Directory user accounts and exports the results to a CSV file. Selected properties are also displayed in an Out-GridView window.
+
+## How It Works
+1. Starts a transcript to log the script's output.
+2. Verifies that PowerShell 7 or later is running and that the **ActiveDirectory** module is available.
+3. Retrieves all user objects with all properties from AD (`Get-ADUser -Properties * -Filter *`).
+4. Exports the data to `$csvpath` using the specified `-Delimiter` and `-Encoding`.
+5. Displays key properties in a graphical table (Out-GridView).
+6. Logs start and end times as well as any errors.
+
+## Parameters
+- **csvpath** *(optional)*: Output file path. Default: `c:\temp\output.csv`.
+- **encoding** *(optional)*: Encoding for the CSV file. Valid values: `UTF8`, `ASCII`, `UTF7`, `UTF32`, `Default`, `Unicode`.
+- **delimiter** *(optional)*: Delimiter for the CSV file. Options: `;`, `,`, ``t`, `|`.
+
+## Dependencies
+- PowerShell 7 or later
+- Module **shibis-pwsh-admin-module** (provides `Check-RequiredModules`, `Handle-Error`, `Log-Information`)
+- ActiveDirectory module
+
+## Example
+```powershell
+./userInformations.ps1 -csvpath "C:\temp\users.csv" -encoding UTF8 -delimiter ";"
+```
+
+## Notes
+- Version: 1.0

--- a/GuiExamples/get_all_processes_GUI.md
+++ b/GuiExamples/get_all_processes_GUI.md
@@ -1,0 +1,16 @@
+# get_all_processes_GUI.ps1
+
+This short example script displays all running processes in an Out-GridView window and prints additional information for any selected process.
+
+## How It Works
+1. Retrieves currently running processes with `Get-Process`.
+2. Opens an Out-GridView window listing the processes. Using `-PassThru`, one or more processes can be selected.
+3. For each selected process, the console outputs its name, ID, and CPU time.
+
+## Example
+```powershell
+./get_all_processes_GUI.ps1
+```
+
+## Notes
+- Version: 1.0

--- a/GuiExamples/start_gui.md
+++ b/GuiExamples/start_gui.md
@@ -1,0 +1,25 @@
+# start_gui.ps1
+
+This script creates a Windows Forms interface that launches PowerShell scripts via buttons. Available scripts are read from a configuration file and can be managed through a dialog.
+
+## How It Works
+1. Loads the required .NET assemblies for **System.Windows.Forms** and **System.Drawing**.
+2. Reads the `scripts.cfg` file in the script directory. Each entry generates a button.
+3. The **Config** button opens a dialog where scripts can be added, edited, removed, and saved.
+4. The form adjusts dynamically to the number of script buttons.
+5. Clicking a script button launches the corresponding script in a new PowerShell instance.
+
+## Configuration File
+The `scripts.cfg` file uses the following format:
+```
+[ScriptName]
+Path=C:\Path\to\Script.ps1
+```
+
+## Example
+```powershell
+./start_gui.ps1
+```
+
+## Notes
+- Version: 1.0

--- a/Server_Cleaning/Log_Cleaning.md
+++ b/Server_Cleaning/Log_Cleaning.md
@@ -1,0 +1,30 @@
+# Log_Cleaning.ps1
+
+This script deletes log files with a specific extension that are older than a defined number of days. Information about deleted files can be exported to a CSV file.
+
+## How It Works
+1. Starts a transcript and records start and end times.
+2. Checks whether the provided path exists and whether it is a file or directory.
+3. Recursively searches for files with the given extension whose `LastWriteTime` is older than the threshold.
+4. Deletes the old files and collects details (name, path, last modified time).
+5. Optionally exports the list of deleted files as a CSV (`csvpath`, `encoding`, `delimiter`).
+
+## Parameters
+- **Path** *(required)*: File or directory to clean.
+- **Days** *(required)*: Age in days beyond which files are removed.
+- **FileEnding** *(required)*: File extension to delete.
+- **csvpath** *(optional)*: Output path for the CSV file. Default: `output.csv` in the script directory.
+- **encoding** *(optional)*: Encoding for the CSV file.
+- **delimiter** *(optional)*: Delimiter for the CSV file.
+
+## Dependencies
+- PowerShell 7 or later
+- Module **shibis-pwsh-admin-module** (e.g., `Handle-Error`, `Log-Information`)
+
+## Example
+```powershell
+./Log_Cleaning.ps1 -Path "C:\Logs" -Days 30 -FileEnding "log"
+```
+
+## Notes
+- Version: 1.0

--- a/Server_Docs/list_all_Services.md
+++ b/Server_Docs/list_all_Services.md
@@ -1,0 +1,27 @@
+# list_all_Services.ps1
+
+This script exports information about all services on the local system to a CSV file.
+
+## How It Works
+1. Starts a transcript and logs start and end times.
+2. Checks whether the custom `shibis_pwsh_admin_module` is loaded.
+3. Retrieves all services via `Get-Service` and selects relevant properties.
+4. Exports the data to a CSV file using the `csvpath`, `encoding`, and `delimiter` parameters.
+5. Uses `Log-Information` and `Handle-Success` for logging.
+
+## Parameters
+- **csvpath** *(optional)*: Location of the CSV file. Default: `c:\temp\output.csv`.
+- **encoding** *(optional)*: Encoding of the CSV file. Default: `UTF8`.
+- **delimiter** *(optional)*: Delimiter used in the CSV file. Default: `;`.
+
+## Dependencies
+- Module **shibis-pwsh-admin-module**
+- PowerShell 7 or later
+
+## Example
+```powershell
+./list_all_Services.ps1 -csvpath "C:\temp\services.csv"
+```
+
+## Notes
+- Version: 1.0

--- a/Template_pwsh.md
+++ b/Template_pwsh.md
@@ -1,0 +1,21 @@
+# Template_pwsh.ps1
+
+This script serves as a template for new PowerShell scripts in this repository.
+
+## How It Works
+1. Includes comment-based help as a starting point for your own descriptions and examples.
+2. Provides a standardized structure with `Begin`, `Process`, and `End` blocks.
+3. Starts a transcript and logs start and end times.
+4. Checks whether PowerShell 7 or later is running.
+5. Offers placeholders for custom logic in the `Process` block and leverages `Log-Information`/`Handle-Error` from the `shibis_pwsh_admin_module`.
+
+## Parameters
+- **csvpath** *(optional)*: Default output path `c:\temp\output.csv`.
+- **encoding** *(optional)*: Predefined list of possible encodings.
+- **delimiter** *(optional)*: Predefined delimiters.
+
+## Usage
+Copy and adapt this template when creating a new script.
+
+## Notes
+- Version: 1.0

--- a/Tests/shibis_pwsh_admin_module.Tests.md
+++ b/Tests/shibis_pwsh_admin_module.Tests.md
@@ -1,0 +1,20 @@
+# shibis_pwsh_admin_module.Tests.ps1
+
+This Pester test script verifies core functions of the `shibis_pwsh_admin_module`.
+
+## How It Works
+1. Imports the module under test from `..\Module\shibis_pwsh_admin_module.psm1`.
+2. Contains multiple `Describe` blocks with tests:
+   - **Required Modules**: checks that necessary modules are available.
+   - **Logging**: tests `Log-Information` by writing to and reading from a log file.
+   - **Error Handling**: expects a function to throw an error.
+   - **Parameter Validation**: ensures `Validate-Parameters` accepts valid parameters.
+   - **Function Output**: confirms `Process-Csv` returns results for valid input.
+
+## Execution
+```powershell
+Invoke-Pester -Script ./shibis_pwsh_admin_module.Tests.ps1
+```
+
+## Notes
+- Version: 1.0


### PR DESCRIPTION
## Summary
- translate Active Directory utility docs to English
- document GUI sample scripts and server maintenance utilities in English
- add English references for template and module test script

## Testing
- `pwsh -NoLogo -NoProfile -Command "Install-Module -Name Pester -Force"` *(fails: No match found for Pester)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: Invoke-Pester not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0ab935848323936ae9e3eea3bb99